### PR TITLE
fix: rewlos should be actual value

### DIFF
--- a/Preprocess1.R
+++ b/Preprocess1.R
@@ -127,10 +127,10 @@ BD$Srewlos[is.na(BD$Srewlos)] <- 0
 
 # now recode absmoney1 into a new variable called rewlos that is the absolute value of absmoney1
 
-AB$rewlos <- abs(AB$absmoney1) 
+AB$rewlos <- AB$absmoney1
 AB$rewlos[is.na(AB$rewlos)] <- 0
 
-BD$rewlos <- abs(BD$absmoney1) 
+BD$rewlos <- BD$absmoney1 
 BD$rewlos[is.na(BD$rewlos)] <- 0
 
 


### PR DESCRIPTION
I saw that you are taking the absolute value of the outcome value and storing it in the `rewlos` field for the model. However, I think this should just be the raw value (at least, that is what the model expects). This could potentially be causing some issues in the modeling.

I could be missing something about the task though!  Let me know what you think. 