### PR TITLE
fix: scale rewlos by 100 like in original model

### DIFF
--- a/Code/R/0_Preprocess/Preprocess1.R
+++ b/Code/R/0_Preprocess/Preprocess1.R
@@ -129,11 +129,11 @@ BD$Srewlos[is.na(BD$Srewlos)] <- 0
 
 
 # now recode absmoney1 into a new variable called rewlos that is the value of absmoney1
-
-AB$rewlos <- AB$absmoney1
+# Scale by 100 like in the original model (since outcomes go up to the 1000's)
+AB$rewlos <- AB$absmoney1 / 100
 AB$rewlos[is.na(AB$rewlos)] <- 0
 
-BD$rewlos <- BD$absmoney1 
+BD$rewlos <- BD$absmoney1 / 100
 BD$rewlos[is.na(BD$rewlos)] <- 0
 
 

--- a/Code/R/1_Analyses/two-step_analyses_pars.R
+++ b/Code/R/1_Analyses/two-step_analyses_pars.R
@@ -1,5 +1,5 @@
-Sess1 <- read.csv("/Users/tuo09169/Dropbox/1_Comp_Modelling/1_IGT_PlayPass/IGT_PP_Shared/Data/2_Fitted/IGT_PP_sep_sess1_IndPars.csv")
-Sess2 <- read.csv("/Users/tuo09169/Dropbox/1_Comp_Modelling/1_IGT_PlayPass/IGT_PP_Shared/Data/2_Fitted/IGT_PP_sep_sess2_IndPars.csv")
+Sess1 <- read.csv(here("Data", "2_Fitted", "IGT_PP_sep_sess1_IndPars.csv"))
+Sess2 <- read.csv(here("Data", "2_Fitted", "IGT_PP_sep_sess2_IndPars.csv"))
 
 # merge the data by subjID
 BothSess <- merge(Sess1,Sess2,by="subjID") 

--- a/Code/R/2_Plotting/posterior_predictive_checks.R
+++ b/Code/R/2_Plotting/posterior_predictive_checks.R
@@ -43,21 +43,6 @@ subj_list <- stan_dat1["subjID"]
 
 subj_list <- as.data.frame(stan_dat1["subjID"])
 
-igt_plots <- foreach(stim=1:4) %do% {
-  #subj <- subj_list[i]
-  print(stim) #so far, cycling through the stim list
-  y <- foreach(i=seq_along(subj_list), .combine = "rbind") %do% {
-    # in line below, -1 recodes the play & pass values to 0 and 1
-    # that, in the stan-ready data, were 1 for play or 2 for pass
-    stan_dat1$ydata[i,stan_dat1$stim[i,]==stim]-1
-  } %>%
-    colMeans()
-}
-
-
-
-
-
 
 # NOTE: this `i=seq_along(subj_list)` loop was used in my code because I was
 # showing plots of different groups of subjects. We do not necessarily need to 
@@ -74,7 +59,7 @@ igt_plots <- foreach(i=seq_along(subj_list)) %do% {
     # is then trying to grab an index that does not exist because 
     # `dim(stan_dat1$ydata)` is only `(49, 120)`. One potential fix could be to 
     # iterate over `seq_along(subjs)` as opposed to just `subjs`.
-    y <- foreach(subj=subjs, .combine = "rbind") %do% {
+    y <- foreach(subj=seq_along(subjs), .combine = "rbind") %do% {
       # ydata is NxT matrix where rows = subjects and columns = trials
       # below grabs the response on trials where subject was presented 
       # a given stimulus
@@ -83,7 +68,7 @@ igt_plots <- foreach(i=seq_along(subj_list)) %do% {
       colMeans()
     
     # Group-level posterior predictions for each trial
-    yrep <- foreach(subj=subjs, .combine = "acomb") %do% {
+    yrep <- foreach(subj=seq_along(subjs), .combine = "acomb") %do% {
       # below follows same logic as above, but with posterior predictions
       # instead of actual data
       pars$y_pred[,subj,stan_dat1$stim[subj,]==stim]-1


### PR DESCRIPTION
@hollysully I realized when looking through that the outcomes are like in the original IGT and go up to -1150. In the original model, we rescaled these outcomes all by 100 (e.g., `outcome = outcome / 100`) because the large numbers can do strange things with the model parameters. 

That said, I re-ran and generated the posterior predictive plots for the first session and got the following posterior predictions: 

![plot_zoom_png](https://user-images.githubusercontent.com/25613611/221368207-763c86a8-0153-4848-9bbc-eec4896a87bf.jpeg)

The fit looks a bit better! The learning rates also have a much more reasonable looking range:

![plot](https://user-images.githubusercontent.com/25613611/221369240-d94073e2-5aed-4e1a-9d0d-7120e6bfd082.jpeg)

Finally, I re-ran the correlations and got these: 

- Arew r = 0.2643265
- Apun r = 0.4546271
- K r = -0.002890668
- betaF r = 0.4866818
- betaP r = 0.4348581

Which are pretty consistent with before. Anyway, I think the improvement in fit (for deck D in the bottom right in particular) makes it clear that we should do the rescaling. Curious what you think! For reference, here is the plot you sent me for the posterior predictions without rescaling: 

![PP_IGT_PPC_fig](https://user-images.githubusercontent.com/25613611/221368379-bfcde326-957b-44a7-8975-959393d22bd8.jpeg)


